### PR TITLE
Add docker compose for containerizing the pose estimation server

### DIFF
--- a/aruco_pose_estimation/launch/erf_demo.launch.xml
+++ b/aruco_pose_estimation/launch/erf_demo.launch.xml
@@ -1,17 +1,22 @@
 <launch>
+    <arg name="image_topic" default="/camera/camera/color/image_raw"/>
+    <arg name="camera_frame" default="camera_color_optical_frame"/>
+    <arg name="marker_size" default="0.097"/>
+    <arg name="tool_frame" default="ur10e_base_link"/>
+
     <node name="aruco_pose_estimation" pkg="aruco_pose_estimation" exec="aruco_node.py">
-        <param name="marker_size" value="0.097"/>
+        <param name="marker_size" value="$(var marker_size)"/>
         <param name="aruco_dictionary_id" value="DICT_ARUCO_ORIGINAL"/>
-        <param name="image_topic" value="/camera/camera/color/image_raw"/>
+        <param name="image_topic" value="$(var image_topic)"/>
         <param name="use_depth_input" value="false"/>
         <!-- <param name="depth_image_topic" value=/> -->
         <param name="camera_info_topic" value="/camera/camera/color/camera_info" />
-        <param name="camera_frame" value="camera_color_optical_frame"/>
+        <param name="camera_frame" value="$(var camera_frame)"/>
         <param name="detected_markers_topic" value="/aruco/markers"/>
         <param name="markers_visualization_topic" value="/aruco/poses"/>
         <param name="output_image_topic" value="/aruco/image"/>
     </node>
 
-    <!-- Realsense eye in hand calibration from easy_handeye2 package -->
-    <node name="static_transform_publisher" pkg="tf2_ros" exec="static_transform_publisher" args="--frame-id link6 --child-frame-id camera_color_optical_frame --x -0.091866 --y -0.038885 --z -0.004517 --qx -0.509167 --qy -0.502857 --qz 0.506293 --qw 0.481197"/> 
+    <!-- TF: tool-> camera. Using eye in hand calibration from easy_handeye2 package -->
+    <node name="static_transform_publisher" pkg="tf2_ros" exec="static_transform_publisher" args="--frame-id $(var tool_frame) --child-frame-id $(var camera_frame) --x -0.091866 --y -0.038885 --z -0.004517 --qx -0.509167 --qy -0.502857 --qz 0.506293 --qw 0.481197"/> 
 </launch>

--- a/docker/.env
+++ b/docker/.env
@@ -1,0 +1,14 @@
+# ros vars
+ROS_DOMAIN_ID=31
+POSE_EST_SRC_DIR=/home/coresense/workspaces/erf_ws/src/ros2-aruco-pose-estimation
+TARGET_WS_DIR =/home/ros/target_ws
+
+# aruco pose estimation server variables
+IMAGE_TOPIC=/camera/camera/color/image_raw
+CAMERA_FRAME=camera_color_optical_frame
+TOOL_FRAME=ur10e_base_link
+MARKER_SIZE=0.097
+
+# aruco pose estimation client variables
+PUBLISH_TF=true
+CHILD_FRAME_ID=aruco_marker

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,16 @@
+FROM registry.tudelft.nl/samxl/humble_dev_base:0.0.2 as pose_estimation_builder
+
+RUN sudo apt-get update && \
+    sudo apt-get install -y --no-install-recommends \
+    ros-humble-tf-transformations
+
+RUN pip3 install --upgrade opencv-python==4.10.0.82
+
+COPY aruco_pose_estimation /home/ros/target_ws/src/aruco_pose_estimation
+COPY aruco_interfaces /home/ros/target_ws/src/aruco_interfaces
+
+WORKDIR /home/ros/target_ws
+RUN sudo chown ros:ros .
+RUN source /ros_entrypoint.sh && \
+    colcon build 
+RUN sudo rm -rf build log src

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,13 @@
+services:
+  pose_estimation-server:
+    build:
+      context: ${POSE_EST_SRC_DIR}
+      dockerfile: docker/Dockerfile
+    image: pose_estimation:latest
+    environment:
+      - ROS_DOMAIN_ID=${ROS_DOMAIN_ID}
+      - ROS_LOCALHOST_ONLY=${ROS_LOCALHOST_ONLY}
+    network_mode: host
+    ipc: host
+    command: /bin/bash -c 'source install/setup.bash && ros2 launch aruco_pose_estimation erf_demo.launch.xml image_topic:=${IMAGE_TOPIC} camera_frame:=${CAMERA_FRAME} tool_frame:=${TOOL_FRAME}'
+    


### PR DESCRIPTION
This MR adds containerization support for running pose estimation as a server

Jira issue: [NXT03-309](https://samxl.atlassian.net/browse/NXT03-309)

## Motivation and Context
The `/estimate_pose` server is useful to localize an aruco marker in the camera frame. The client can then call this service on command line. This MR adds support for running the pose_estimation server using a docker compose file. The provided dockerfile also allows us to reproduce the setup on any PC where there is an incoming camera stream.
 
## Changes

- `.env`: User variables for running the docker compose and ros services
- `docker-compose.yml`: Compose file which runs a pose estimation server.
- `Dockerfile`: Extends the humble_dev_base image on the registry to work with this repository. It also cleans up build artefacts to make the image smaller
- `erf_demo.launch.xml`: Added arguments to the launch file for common variables so that compose can launch it directly.

## Type of changes
- New feature (non-breaking change which adds functionality)
[comment]: # (Delete or add more as appropriate)

## Test Guidelines and Expected Behaviour 
**Terminal 1: On the Nvidida Jetson**
```
docker start realsense_jetson-service
```
^ if you dont have this available, make sure you have a camera image being published on the same ros network on the IMAGE_TOPIC variable in the .env file.

**Terminal 2: On the NUC** (or any other PC on same network)
In the root directory, build+run the image
```
docker compose -f docker/docker-compose.yml up --build
```
If everything worked correctly, you should see the server running and no errors. 

**Terminal 3: On the NUC** (or any other PC on same network)
```
ros2 service call /estimate_pose aruco_interfaces/srv/EstimatePose
```
You should see the service complete succesfully and output something like:
```
response:
aruco_interfaces.srv.EstimatePose_Response(success=True, transform=geometry_msgs.msg.TransformStamped(header=std_msgs.msg.Header(stamp=builtin_interfaces.msg.Time(sec=1741791161, nanosec=315220459), frame_id='camera_color_optical_frame'), child_frame_id='aruco_marker', transform=geometry_msgs.msg.Transform(translation=geometry_msgs.msg.Vector3(x=0.24766015216684453, y=-0.08916882213643311, z=0.896478459727375), rotation=geometry_msgs.msg.Quaternion(x=-0.6938320223320007, y=-0.12386247083062231, z=0.6993181601643609, w=0.11920286897030985))))
```