### PR TITLE
Add pose estimation client for automatic xacro update

### DIFF
--- a/aruco_interfaces/srv/EstimatePose.srv
+++ b/aruco_interfaces/srv/EstimatePose.srv
@@ -1,4 +1,5 @@
 bool publish_tf false   # publish the transform once
+string parent_frame_id 'camera_link'    # the transform is with respect to this frame id
 string child_frame_id 'aruco_marker'    # the transform is created with this frame id
 ---
 bool success

--- a/aruco_pose_estimation/CMakeLists.txt
+++ b/aruco_pose_estimation/CMakeLists.txt
@@ -27,6 +27,7 @@ ament_python_install_package(${PROJECT_NAME})
 # Install Python executables
 install(PROGRAMS
     scripts/aruco_node.py
+    scripts/pose_estimation_client.py
     DESTINATION lib/${PROJECT_NAME}
 )
 

--- a/aruco_pose_estimation/launch/pose_estimation_client.launch.xml
+++ b/aruco_pose_estimation/launch/pose_estimation_client.launch.xml
@@ -1,0 +1,9 @@
+<launch>
+    <node name="pose_estimation_client" pkg="aruco_pose_estimation" exec="pose_estimation_client.py" output="screen">
+        <param name="update_xacro" value="true"/>
+        <param name="xacro_path" value="$(find-pkg-share aruco_pose_estimation)/config/coby.xacro"/>
+        <param name="parent_frame_id" value="rs"/>
+        <param name="child_frame_id" value="aruco_marker"/>
+        <remap from="estimate_pose_srv" to="/estimate_pose"/>
+    </node>
+</launch>

--- a/aruco_pose_estimation/scripts/pose_estimation_client.py
+++ b/aruco_pose_estimation/scripts/pose_estimation_client.py
@@ -1,0 +1,137 @@
+#!/usr/bin/python3
+
+"""pose_estimation_client.py_
+
+A ros node that calls the pose estimation service and updates the pose in the mentioned xacro
+"""
+import rclpy
+from rclpy.node import Node
+from aruco_interfaces.srv import EstimatePose
+import xml.etree.ElementTree as ET
+from scipy.spatial.transform import Rotation
+import os
+
+class PoseEstimationClient(Node):
+    def __init__(self, name):
+        super().__init__(node_name=name)
+        self.logger = self.get_logger()
+
+        # ROS parameters
+        self.declare_parameter('parent_frame_id', 'camera_link')
+        self.declare_parameter('child_frame_id', 'aruco_marker')
+        self.declare_parameter('publish_tf', False)
+        self.declare_parameter('update_xacro', True)
+        self.declare_parameter('xacro_path', "")
+         
+        self._client = self.make_srv_client('estimate_pose_srv', EstimatePose, required=True)
+        self.run()
+        self.logger.info("Done.")
+        self.destroy_node()
+        exit(0)
+
+    def run(self):
+        parent_frame_id = self.get_parameter("parent_frame_id").value
+        child_frame_id = self.get_parameter("child_frame_id").value
+        publish_tf = self.get_parameter("publish_tf").value
+        update_xacro = self.get_parameter("update_xacro").value
+
+        response = self.estimate_pose(parent_frame_id, child_frame_id, publish_tf)
+        if not response.success:
+            self.logger.error("Pose estimation failed. Skipping xacro update")
+            update_xacro = False    
+        else:
+            self.logger.info("Pose estimation successful.")
+            self.logger.info(f"Translation: {response.transform.transform.translation}")
+            self.logger.info(f"Received pose: rotation: {response.transform.transform.rotation}")
+
+        if update_xacro:
+            xacro_path = self.get_parameter("xacro_path").get_parameter_value().string_value
+            self.logger.info(f"Updating xacro path: {xacro_path}")
+            try:
+                if not os.path.exists(xacro_path):
+                    raise FileNotFoundError
+                self.update_xacro(response.transform, xacro_path)
+            except Exception as e:
+                self.logger.error(f"Xacro update failed. Error: {e}")
+
+
+    def make_srv_client(self, srv_name, srv_type, required=True):
+        """Help in creating and handling service clients."""
+        self.logger.info("Waiting for service..")
+        client = self.create_client(srv_type, srv_name)
+        if not client.wait_for_service(timeout_sec=5.0):
+            remapped_srv_name = self.resolve_service_name(srv_name)
+            msg = f"Timed out waiting for server: '{remapped_srv_name}'"
+            if required:
+                self.logger.fatal(msg)
+                raise RuntimeError(msg)
+            self.logger.info(msg)
+        return client
+    
+    def estimate_pose(self, parent_frame_id, child_frame_id, publish_tf):
+        request = EstimatePose.Request()
+        request.publish_tf = publish_tf
+
+        request.parent_frame_id = parent_frame_id
+        request.child_frame_id = child_frame_id
+        
+        future = self._client.call_async(request)
+        rclpy.spin_until_future_complete(self, future)
+        response = future.result()
+
+        return response
+    
+    def update_xacro(self, transform, xacro_path):
+        tree, cell_description = self.get_cell_description(xacro_path)
+        
+        self.update_cell_description(cell_description, transform)
+        tree.write(xacro_path)
+
+    @staticmethod
+    def update_cell_description(cell_description, transform):
+        cell_description.attrib["parent"] = transform.header.frame_id
+        cell_description.attrib["child"] = transform.child_frame_id
+
+        origin = cell_description.find('origin')
+        position = transform.transform.translation
+        orientation = transform.transform.rotation
+        
+        origin.attrib['xyz'] = f"{position.x:0.3f} {position.y:0.3f} {position.z:0.3f}"
+
+        rpy = Rotation.from_quat([orientation.x, orientation.y, orientation.z, orientation.z]).as_euler('xyz')
+
+        origin.attrib['rpy'] = f"{rpy[0]:0.3f} {rpy[1]:0.3f} {rpy[2]:0.3f}"
+
+    @staticmethod
+    def get_cell_description(xacro_path) -> ET.Element:
+        """Get the cell description macro element from the xacro
+
+        Args:
+            xacro_path (str): path to the xacro file
+
+        Returns:
+            ET.ElementTree: The original element tree. Need it for writing out
+            ET.Element: The element to be modified using pose estimation
+        """
+        # need to do this otherwise the default ns0 namespace is used
+        ET.register_namespace('xacro', "http://wiki.ros.org/xacro")
+        tree = ET.parse(xacro_path)
+        robot = tree.getroot()
+        cell_description_macro = robot.find('{http://wiki.ros.org/xacro}cell_description_macro')
+
+        return tree, cell_description_macro
+    
+
+def main(args=None):
+    """Launch the ROS node.
+
+    Args:
+        args (list[str], optional): Args to pass to init for rclpy. Defaults to None.
+    """
+    rclpy.init(args=args)
+    node = PoseEstimationClient("pose_estimation_client")
+    rclpy.spin(node)
+    rclpy.shutdown()
+
+if __name__ == "__main__":
+    main()

--- a/aruco_pose_estimation/scripts/pose_estimation_client.py
+++ b/aruco_pose_estimation/scripts/pose_estimation_client.py
@@ -41,8 +41,9 @@ class PoseEstimationClient(Node):
             update_xacro = False    
         else:
             self.logger.info("Pose estimation successful.")
-            self.logger.info(f"Translation: {response.transform.transform.translation}")
-            self.logger.info(f"Received pose: rotation: {response.transform.transform.rotation}")
+            xyz, rpy = self.transform_to_pose(response.transform.transform)
+            self.logger.info(f"Translation [xyz, metres]: {xyz}")
+            self.logger.info(f"Rotation [rpy, radians]: {rpy}")
 
         if update_xacro:
             xacro_path = self.get_parameter("xacro_path").get_parameter_value().string_value
@@ -88,18 +89,20 @@ class PoseEstimationClient(Node):
         tree.write(xacro_path)
 
     @staticmethod
-    def update_cell_description(cell_description, transform):
+    def transform_to_pose(transform):
+        xyz = transform.translation
+        quat = transform.rotation
+        rpy = Rotation.from_quat([quat.x, quat.y, quat.z, quat.z]).as_euler('xyz')
+        return xyz, rpy
+
+    def update_cell_description(self, cell_description, transform):
         cell_description.attrib["parent"] = transform.header.frame_id
         cell_description.attrib["child"] = transform.child_frame_id
 
-        origin = cell_description.find('origin')
-        position = transform.transform.translation
-        orientation = transform.transform.rotation
-        
-        origin.attrib['xyz'] = f"{position.x:0.3f} {position.y:0.3f} {position.z:0.3f}"
+        xyz, rpy = self.transform_to_pose(transform.transform)
 
-        rpy = Rotation.from_quat([orientation.x, orientation.y, orientation.z, orientation.z]).as_euler('xyz')
-
+        origin = cell_description.find('origin')        
+        origin.attrib['xyz'] = f"{xyz.x:0.3f} {xyz.y:0.3f} {xyz.z:0.3f}"
         origin.attrib['rpy'] = f"{rpy[0]:0.3f} {rpy[1]:0.3f} {rpy[2]:0.3f}"
 
     @staticmethod

--- a/docker/docker-compose.oneshot.yml
+++ b/docker/docker-compose.oneshot.yml
@@ -15,5 +15,5 @@ services:
       - ROS_LOCALHOST_ONLY=${ROS_LOCALHOST_ONLY}
     network_mode: host
     ipc: host
-    command: /bin/bash -c 'source install/setup.bash && ros2 service call /estimate_pose aruco_interfaces/srv/EstimatePose'
+    command: /bin/bash -c 'source install/setup.bash && ros2 launch aruco_pose_estimation pose_estimation_client.launch.xml'
     


### PR DESCRIPTION
This MR adds a pose estimation client that calls the pose estimation server and optionally updates the estimated pose in a given xacro file

Jira issue: [NXT03-310](https://samxl.atlassian.net/browse/NXT03-310)

## Motivation and Context
Th pose estimation client service from #3 called a service from command line, printed out the pose and the user had to manually change the pose in a potential xacro file. To automate this, a pose estimation client python file was created in this MR and the xacro gets updated automatically.

## Changes

- `EstimatePose.srv`: Update the request with a `parent_frame_id`.
- `pose_estimation_client.py`: File that calls the `estimate_pos_srv` service, reads and writes to the given `xacro_path`
- `pose_estimation_client.launch.xml`: Convenence launch file for calling the client node
- `docker-compose.oneshot.yml`: Update the command argument to call a new launch file

## Type of changes
- New feature (Breaking change which adds functionality)

## Test Guidelines and Expected Behaviour 
**Terminal 1: On the Nvidida Jetson**
```
docker start realsense_jetson-service
```
^ if you dont have this available, make sure you have a camera image being published on the same ros network on the IMAGE_TOPIC variable in the .env file.

**Terminal 2: On the NUC** (or any other PC on same network)
In the root directory, run the containers (assuming already built
```
docker compose -f docker/docker-compose.oneshot.yml  up --abort-on-container-exit
```
If everything worked correctly, you should see the server startup and the client call which outputs the transform and updates a test xacro located in `test/coby_env.xacro`
