### PR TITLE
Use the robot base_link as the parent frame for estimation

### DIFF
--- a/aruco_pose_estimation/CMakeLists.txt
+++ b/aruco_pose_estimation/CMakeLists.txt
@@ -33,7 +33,7 @@ install(PROGRAMS
 
 # Install directories
 install(DIRECTORY
-    launch rviz config
+    launch rviz config test
     DESTINATION share/${PROJECT_NAME}
 )
 ament_package()

--- a/aruco_pose_estimation/launch/pose_estimation_client.launch.xml
+++ b/aruco_pose_estimation/launch/pose_estimation_client.launch.xml
@@ -1,8 +1,8 @@
 <launch>
     <node name="pose_estimation_client" pkg="aruco_pose_estimation" exec="pose_estimation_client.py" output="screen">
         <param name="update_xacro" value="true"/>
-        <param name="xacro_path" value="$(find-pkg-share aruco_pose_estimation)/test/coby_env.xacro"/>
-        <param name="parent_frame_id" value="rs"/>
+        <param name="xacro_path" value="/home/ros/urdf/coby_env_test.xacro"/>
+        <param name="parent_frame_id" value="ur10e_base_link"/>
         <param name="child_frame_id" value="aruco_marker"/>
         <remap from="estimate_pose_srv" to="/estimate_pose"/>
     </node>

--- a/aruco_pose_estimation/launch/pose_estimation_client.launch.xml
+++ b/aruco_pose_estimation/launch/pose_estimation_client.launch.xml
@@ -1,7 +1,7 @@
 <launch>
     <node name="pose_estimation_client" pkg="aruco_pose_estimation" exec="pose_estimation_client.py" output="screen">
         <param name="update_xacro" value="true"/>
-        <param name="xacro_path" value="/home/ros/urdf/coby_env_test.xacro"/>
+        <param name="xacro_path" value="/home/ros/urdf/coby_env.xacro"/>
         <param name="parent_frame_id" value="ur10e_base_link"/>
         <param name="child_frame_id" value="aruco_marker"/>
         <remap from="estimate_pose_srv" to="/estimate_pose"/>

--- a/aruco_pose_estimation/launch/pose_estimation_client.launch.xml
+++ b/aruco_pose_estimation/launch/pose_estimation_client.launch.xml
@@ -1,7 +1,7 @@
 <launch>
     <node name="pose_estimation_client" pkg="aruco_pose_estimation" exec="pose_estimation_client.py" output="screen">
         <param name="update_xacro" value="true"/>
-        <param name="xacro_path" value="$(find-pkg-share aruco_pose_estimation)/config/coby.xacro"/>
+        <param name="xacro_path" value="$(find-pkg-share aruco_pose_estimation)/test/coby_env.xacro"/>
         <param name="parent_frame_id" value="rs"/>
         <param name="child_frame_id" value="aruco_marker"/>
         <remap from="estimate_pose_srv" to="/estimate_pose"/>

--- a/aruco_pose_estimation/scripts/aruco_node.py
+++ b/aruco_pose_estimation/scripts/aruco_node.py
@@ -57,8 +57,8 @@ from aruco_interfaces.msg import ArucoMarkers
 from aruco_interfaces.srv import EstimatePose
 from rcl_interfaces.msg import ParameterDescriptor, ParameterType
 from rclpy.qos import qos_profile_sensor_data, QoSHistoryPolicy, QoSProfile
-from tf2_ros import TransformBroadcaster
-
+from tf2_ros import TransformBroadcaster, TransformListener, Buffer
+from tf2_geometry_msgs.tf2_geometry_msgs import _decompose_affine, _transform_to_affine
 
 class ArucoNode(rclpy.node.Node):
     def __init__(self):
@@ -88,6 +88,9 @@ class ArucoNode(rclpy.node.Node):
         self.info_sub = self.create_subscription(
             CameraInfo, self.info_topic, self.info_callback, qos_profile_sensor_data
         )
+
+        self.tf_buffer = Buffer()
+        self.tf_listener = TransformListener(self.tf_buffer, self)
         self.tf_broadcaster = TransformBroadcaster(self)
 
         # select the type of input to use for the pose estimation
@@ -359,7 +362,7 @@ class ArucoNode(rclpy.node.Node):
             markers.header.frame_id = self.camera_frame
             pose_array.header.frame_id = self.camera_frame
 
-        transform = TransformStamped()
+        T_marker_cam = TransformStamped()
 
         try:
             frame, pose_array, markers = pose_estimation(rgb_frame=self.cv_image, depth_frame=None,
@@ -368,24 +371,32 @@ class ArucoNode(rclpy.node.Node):
                                                      distortion_coefficients=self.distortion, pose_array=pose_array, markers=markers)
             # Return the first pose as the transform
             if len(markers.marker_ids)>0:
-                transform.header.stamp = self.get_clock().now().to_msg()
-                transform.header.frame_id = self.camera_frame
-                transform.child_frame_id = request.child_frame_id
+                T_marker_cam.header.stamp = self.get_clock().now().to_msg()
+                T_marker_cam.header.frame_id = "rs"
+                T_marker_cam.child_frame_id = request.child_frame_id
 
-                transform.transform.translation.x = pose_array.poses[0].position.x
-                transform.transform.translation.y = pose_array.poses[0].position.y
-                transform.transform.translation.z = pose_array.poses[0].position.z
+                T_marker_cam.transform.translation.x = pose_array.poses[0].position.x
+                T_marker_cam.transform.translation.y = pose_array.poses[0].position.y
+                T_marker_cam.transform.translation.z = pose_array.poses[0].position.z
 
-                transform.transform.rotation.x = pose_array.poses[0].orientation.x
-                transform.transform.rotation.y = pose_array.poses[0].orientation.y
-                transform.transform.rotation.z = pose_array.poses[0].orientation.z
-                transform.transform.rotation.w = pose_array.poses[0].orientation.w
+                T_marker_cam.transform.rotation.x = pose_array.poses[0].orientation.x
+                T_marker_cam.transform.rotation.y = pose_array.poses[0].orientation.y
+                T_marker_cam.transform.rotation.z = pose_array.poses[0].orientation.z
+                T_marker_cam.transform.rotation.w = pose_array.poses[0].orientation.w
                 
                 if request.publish_tf:
-                    self.tf_broadcaster.sendTransform(transform)
+                    self.tf_broadcaster.sendTransform(T_marker_cam)
                 
+                T_cam_base =  self.tf_buffer.lookup_transform("rs", request.parent_frame_id, rclpy.time.Time())
+                T_marker_base = _transform_to_affine(T_marker_cam)@_transform_to_affine(T_cam_base)
+                T_marker_cam = TransformStamped()
+                T_marker_cam.header.frame_id = request.parent_frame_id
+                T_marker_cam.child_frame_id = request.child_frame_id
+
+                T_marker_cam.transform.rotation, T_marker_cam.transform.translation = _decompose_affine(T_marker_base)
+
                 response.success = True
-                response.transform = transform
+                response.transform = T_marker_base
             else:
                 raise ValueError("Pose array is empty")
         except Exception as e:

--- a/aruco_pose_estimation/scripts/aruco_node.py
+++ b/aruco_pose_estimation/scripts/aruco_node.py
@@ -137,7 +137,7 @@ class ArucoNode(rclpy.node.Node):
         # self.aruco_dictionary = cv2.aruco.Dictionary_get(dictionary_id)
         # self.aruco_parameters = cv2.aruco.DetectorParameters_create()
 
-        rclpy.spin_until_future_complete(self, future=self.future_rcv_image, timeout_sec = 5)
+        rclpy.spin_until_future_complete(self, future=self.future_rcv_image, timeout_sec = 10)
         if not self.future_rcv_image.done():
             raise TimeoutError(
                 f"Timed out waiting for image on topic: {self.image_topic}. \n Check if: The image is being publised on the correct topic and namespace."

--- a/aruco_pose_estimation/scripts/aruco_node.py
+++ b/aruco_pose_estimation/scripts/aruco_node.py
@@ -386,14 +386,25 @@ class ArucoNode(rclpy.node.Node):
                 
                 if request.publish_tf:
                     self.tf_broadcaster.sendTransform(T_marker_cam)
-                
-                T_cam_base =  self.tf_buffer.lookup_transform("rs", request.parent_frame_id, rclpy.time.Time())
-                T_marker_base = _transform_to_affine(T_marker_cam)@_transform_to_affine(T_cam_base)
-                T_marker_cam = TransformStamped()
-                T_marker_cam.header.frame_id = request.parent_frame_id
-                T_marker_cam.child_frame_id = request.child_frame_id
 
-                T_marker_cam.transform.rotation, T_marker_cam.transform.translation = _decompose_affine(T_marker_base)
+                # TODO change hardcoded rs. Currently done because frame name in urdf doesn't match self.camera_frame                
+                T_cam_base =  self.tf_buffer.lookup_transform(request.parent_frame_id, "rs" , rclpy.time.Time()) # camera (from_frame_id) with respect to base_link (to_frame_id)
+                mat_marker_base = _transform_to_affine(T_cam_base)@_transform_to_affine(T_marker_cam) # marker with respect to base link
+                
+                # get transform from matrix
+                T_marker_base = TransformStamped()
+                T_marker_base.header.frame_id = request.parent_frame_id
+                T_marker_base.child_frame_id = request.child_frame_id
+
+                orientation, position = _decompose_affine(mat_marker_base)
+                T_marker_base.transform.translation.x = position[0]
+                T_marker_base.transform.translation.y = position[1]
+                T_marker_base.transform.translation.z = position[2]
+
+                T_marker_base.transform.rotation.x = orientation[1]
+                T_marker_base.transform.rotation.y = orientation[2]
+                T_marker_base.transform.rotation.z = orientation[3]
+                T_marker_base.transform.rotation.w = orientation[0]
 
                 response.success = True
                 response.transform = T_marker_base

--- a/aruco_pose_estimation/scripts/pose_estimation_client.py
+++ b/aruco_pose_estimation/scripts/pose_estimation_client.py
@@ -60,7 +60,7 @@ class PoseEstimationClient(Node):
         """Help in creating and handling service clients."""
         self.logger.info("Waiting for service..")
         client = self.create_client(srv_type, srv_name)
-        if not client.wait_for_service(timeout_sec=5.0):
+        if not client.wait_for_service(timeout_sec=10.0):
             remapped_srv_name = self.resolve_service_name(srv_name)
             msg = f"Timed out waiting for server: '{remapped_srv_name}'"
             if required:

--- a/aruco_pose_estimation/scripts/pose_estimation_client.py
+++ b/aruco_pose_estimation/scripts/pose_estimation_client.py
@@ -92,7 +92,7 @@ class PoseEstimationClient(Node):
     def transform_to_pose(transform):
         xyz = transform.translation
         quat = transform.rotation
-        rpy = Rotation.from_quat([quat.x, quat.y, quat.z, quat.z]).as_euler('xyz')
+        rpy = Rotation.from_quat([quat.x, quat.y, quat.z, quat.w]).as_euler('xyz')
         return xyz, rpy
 
     def update_cell_description(self, cell_description, transform):

--- a/aruco_pose_estimation/test/coby_env.xacro
+++ b/aruco_pose_estimation/test/coby_env.xacro
@@ -1,0 +1,44 @@
+<robot xmlns:xacro="http://wiki.ros.org/xacro" name="samxl_coby">
+    
+    <xacro:arg name="fixed" default="true" />
+
+    
+    <link name="mid_mount" />
+
+    
+    <xacro:include filename="$(find cell_description)/urdf/cell_description_macro.xacro" />
+
+        
+    <xacro:cell_description_macro parent="rs" child="aruco_marker" add_parent="false">
+        <origin xyz="0.213 -0.188 0.807" rpy="-3.111 1.001 -1.514" />  
+    </xacro:cell_description_macro>
+
+    <xacro:arg name="ridgeback_arm_height" default="$(optenv RIDGEBACK_ARM_HEIGHT 0.6)" />
+    <xacro:arg name="ridgeback_arm_angle" default="$(optenv RIDGEBACK_ARM_ANGLE 0.0)" />
+    <xacro:arg name="ridgeback_bottom_plate_height" default="0.3" />
+  
+    <material name="dark_grey"><color rgba="0.2 0.2 0.2 1.0" /></material>
+    <material name="light_grey"><color rgba="0.4 0.4 0.4 1.0" /></material>
+    <material name="red"><color rgba="0.8 0.0 0.0 1.0" /></material>
+    <material name="white"><color rgba="0.9 0.9 0.9 1.0" /></material>
+    <material name="yellow"><color rgba="0.8 0.8 0.0 1.0" /></material>
+    <material name="black"><color rgba="0.15 0.15 0.15 1.0" /></material>
+
+    <xacro:include filename="$(find samxl_ridgeback_description)/urdf/samxl_ridgeback_hams.urdf.xacro" />
+    
+
+    
+    <xacro:include filename="$(find samxl_ur10e_description)/urdf/samxl_ur10e_robot_macro.xacro" />
+    <xacro:samxl_ur10e_robot parent="arm_mount_hams_plate_link" prefix="ur10e_">
+        
+        <origin xyz="0 0 0" rpy="0.0 0.0 0" />   
+    </xacro:samxl_ur10e_robot>
+
+    
+    <xacro:include filename="$(find samxl_common_description)/urdf/lls_rs_macro.xacro" />
+
+    <xacro:lls_rs_macro parent="ur10e_tool0" child="mount_link" tcp_offset="0.06">
+        <origin xyz="0.005 0.03 0.0" rpy="${radians(90)} 0 ${radians(90)}" />
+    </xacro:lls_rs_macro>
+
+</robot>

--- a/aruco_pose_estimation/test/coby_env.xacro
+++ b/aruco_pose_estimation/test/coby_env.xacro
@@ -9,8 +9,8 @@
     <xacro:include filename="$(find cell_description)/urdf/cell_description_macro.xacro" />
 
         
-    <xacro:cell_description_macro parent="rs" child="aruco_marker" add_parent="false">
-        <origin xyz="0.213 -0.188 0.807" rpy="-3.111 1.001 -1.514" />  
+    <xacro:cell_description_macro parent="ur10e_base_link" child="aruco_marker" add_parent="false">
+        <origin xyz="-0.687 -0.403 -0.042" rpy="0.034 0.026 -0.007" />  
     </xacro:cell_description_macro>
 
     <xacro:arg name="ridgeback_arm_height" default="$(optenv RIDGEBACK_ARM_HEIGHT 0.6)" />

--- a/docker/.env
+++ b/docker/.env
@@ -1,7 +1,6 @@
 # ros vars
 ROS_DOMAIN_ID=31
 POSE_EST_SRC_DIR=/home/coresense/workspaces/erf_ws/src/ros2-aruco-pose-estimation
-TARGET_WS_DIR =/home/ros/target_ws
 
 # aruco pose estimation server variables
 IMAGE_TOPIC=/camera/camera/color/image_raw

--- a/docker/.env
+++ b/docker/.env
@@ -11,4 +11,5 @@ MARKER_SIZE=0.097
 
 # aruco pose estimation client variables
 PUBLISH_TF=true
+PARENT_FRAME_ID=ur10e_base_link
 CHILD_FRAME_ID=aruco_marker

--- a/docker/client_entrypoint.sh
+++ b/docker/client_entrypoint.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+source install/setup.bash
+ros2 launch aruco_pose_estimation pose_estimation_client.launch.xml \
+    update_xacro:=true \
+    xacro_path:=/home/ros/urdf/coby_env.xacro \
+    parent_frame_id:=ur10e_base_link \
+    child_frame_id:=aruco_marker \
+    estimate_pose_srv:=/estimate_pos
+

--- a/docker/docker-compose.oneshot.yml
+++ b/docker/docker-compose.oneshot.yml
@@ -1,3 +1,5 @@
+name: erf_demo
+
 services:
   pose_estimation-server:
     extends:
@@ -16,7 +18,14 @@ services:
       - ROS_LOCALHOST_ONLY=${ROS_LOCALHOST_ONLY}
     network_mode: host
     volumes:
-      - /home/coresense/SAMXL/coresense-ws/src/coresense-description/urdf:/home/ros/urdf
+      # For real pose estimation
+      # - /home/coresense/SAMXL/coresense-ws/src/coresense-description/urdf/coby_env.xacro:/home/ros/urdf/coby_env.xacro  
+      
+      # For testing (also default behaviour)
+      - ${POSE_EST_SRC_DIR}/aruco_pose_estimation/test/coby_env.xacro:/home/ros/urdf/coby_env.xacro 
+
+      # so you can modify launch file at host during testing
+      - ${POSE_EST_SRC_DIR}/aruco_pose_estimation/launch:/home/ros/target_ws/install/aruco_pose_estimation/share/aruco_pose_estimation/launch
     ipc: host
     command: /bin/bash -c 'source install/setup.bash && ros2 launch aruco_pose_estimation pose_estimation_client.launch.xml'
     

--- a/docker/docker-compose.oneshot.yml
+++ b/docker/docker-compose.oneshot.yml
@@ -5,11 +5,12 @@ services:
       service: pose_estimation-server
 
   pose_estimation-client:
+    container_name: pose_estimation-client
     depends_on:
       pose_estimation-server:
           condition: service_started
     image: pose_estimation:latest
-    working_dir: ${TARGET_WS_DIR}
+    working_dir: /home/ros/target_ws  # prebuilt ros workspace
     environment:
       - ROS_DOMAIN_ID=${ROS_DOMAIN_ID}
       - ROS_LOCALHOST_ONLY=${ROS_LOCALHOST_ONLY}

--- a/docker/docker-compose.oneshot.yml
+++ b/docker/docker-compose.oneshot.yml
@@ -1,4 +1,4 @@
-name: erf_demo
+name: pose_estimation
 
 services:
   pose_estimation-server:
@@ -25,7 +25,7 @@ services:
       - ${POSE_EST_SRC_DIR}/aruco_pose_estimation/test/coby_env.xacro:/home/ros/urdf/coby_env.xacro 
 
       # so you can modify launch file at host during testing
-      - ${POSE_EST_SRC_DIR}/aruco_pose_estimation/launch:/home/ros/target_ws/install/aruco_pose_estimation/share/aruco_pose_estimation/launch
+      - ${POSE_EST_SRC_DIR}/docker/client_entrypoint.sh:/home/ros/target_ws/client_entrypoint.sh
     ipc: host
-    command: /bin/bash -c 'source install/setup.bash && ros2 launch aruco_pose_estimation pose_estimation_client.launch.xml'
+    entrypoint: ./client_entrypoint.sh
     

--- a/docker/docker-compose.oneshot.yml
+++ b/docker/docker-compose.oneshot.yml
@@ -14,6 +14,8 @@ services:
       - ROS_DOMAIN_ID=${ROS_DOMAIN_ID}
       - ROS_LOCALHOST_ONLY=${ROS_LOCALHOST_ONLY}
     network_mode: host
+    volumes:
+      - /home/coresense/SAMXL/coresense-ws/src/coresense-description/urdf:/home/ros/urdf
     ipc: host
     command: /bin/bash -c 'source install/setup.bash && ros2 launch aruco_pose_estimation pose_estimation_client.launch.xml'
     

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,5 +1,6 @@
 services:
   pose_estimation-server:
+    container_name: pose_estimation-server
     build:
       context: ${POSE_EST_SRC_DIR}
       dockerfile: docker/Dockerfile

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,3 +1,5 @@
+name: erf_demo
+
 services:
   pose_estimation-server:
     container_name: pose_estimation-server


### PR DESCRIPTION
This MR modifies the `parent_frame_id` for pose_estimation to use the base link of the robot.

Jira issue: [NXT03-310](https://samxl.atlassian.net/browse/NXT03-310)

## Motivation and Context
In earlier MRs (#4) the pose estimation was done from camera frame to the aruco marker. This is simple, but problematic because the camera moves when the motion plan is executed. We need to do pose estimation between a fixed planning frame and the aruco marker. In this case the fixed frame is the base_llink of the robot.

## Changes

- `aruco_node.py`: Use a lookup transform to get the transform from base_link to camera frame and compose it with the estimated pose from camera frame to aruco_marker
- `pose_estimation_client.py`: Fix a bug in the output of estimated quaternion. Also increased timeouts to allow for a slow camera feed
- `coby_env.xacro`: A xacro file to test pose estimation
- `docker-compose.oneshot.yml`: Added a volume mount in the client so that a host xacro file can be edited within the container

## Type of changes
- New feature (Breaking change which adds functionality)

## Test Guidelines and Expected Behaviour 
**Terminal 1: On the Nvidida Jetson**
```
docker start realsense_jetson-service
```
^ if you dont have this available, make sure you have a camera image being published on the same ros network on the IMAGE_TOPIC variable in the .env file.

**Terminal 2: Run the coby state publisher (in the coresense-state-machine container). On the NUC**
```
ros2 launch coresense_bringup coby_hw_bringup.launch.py
```

**Terminal 3: On the NUC** (or any other PC on same network)
In the root directory, build and run the containers
```
docker compose -f docker/docker-compose.oneshot.yml  up --build
```
If everything worked correctly, you should see the server startup and the client call which outputs the transform and updates a test xacro located in `test/coby_env.xacro`
